### PR TITLE
reads pins 3.26 and 3.25 to determine PCB revision from v12 or v13

### DIFF
--- a/src/modules/utils/simpleshell/SimpleShell.cpp
+++ b/src/modules/utils/simpleshell/SimpleShell.cpp
@@ -12,6 +12,7 @@
 #include "libs/utils.h"
 #include "libs/SerialMessage.h"
 #include "libs/StreamOutput.h"
+#include "libs/Pin.h"
 #include "modules/robot/Conveyor.h"
 #include "DirHandle.h"
 #include "mri.h"
@@ -630,8 +631,20 @@ void SimpleShell::version_command( string parameters, StreamOutput *stream)
 {
     Version vers;
     uint32_t dev = getDeviceType();
+    Pin *rev_bit_0 = new Pin();
+    Pin *rev_bit_1 = new Pin();
+    rev_bit_0->from_string("3.26!^")->as_input();
+    rev_bit_1->from_string("3.25!^")->as_input();
+    safe_delay_us(200);  // make sure the pin has settled
+    uint8_t rev = 12;  // PCB revision number (Production began at v12)
+    if (rev_bit_0->get()) {
+        rev += 1;
+    }
+    if (rev_bit_1->get()) {
+        rev += 2;
+    }
     const char *mcu = (dev & 0x00100000) ? "LPC1769" : "LPC1768";
-    stream->printf("Build version: %s, Build date: %s, MCU: %s, System Clock: %ldMHz\r\n", vers.get_build(), vers.get_build_date(), mcu, SystemCoreClock / 1000000);
+    stream->printf("Build version: %s, Build date: %s, PCB Rev: %d, MCU: %s, System Clock: %ldMHz\r\n", vers.get_build(), vers.get_build_date(), rev, mcu, SystemCoreClock / 1000000);
     #ifdef CNC
     stream->printf("  CNC Build ");
     #endif


### PR DESCRIPTION
A major-version bump is required for new PCBs that tie the A5984's ROSC pin to ground (giving us much smoother motion as slow speeds).

To allow software to automatically detect PCB revisions (ie either version 12 or version 13), this PR adds functionality to determine the rev number by reading the LPC1769's gpio when a `"version"` command is issued. From the state of those gpio, it can tell which PCB revision it is, report back to the host controller.

The pins uses are pins `3.26` and `3.25`, which are set to internally pull-up to 3.3v. If `3.26` is tied to ground (0v), then the pcb revision incremented by 1. If `3.25` is tied to ground, the pcb revision is incremented by 2. This allows the firmware to use 2 gpio to detect revisions 12, 13, 14, or 15.