### PR TITLE
feat(currentcontrol): change current based on revision

### DIFF
--- a/src/config.default
+++ b/src/config.default
@@ -257,6 +257,9 @@ msd_disable                                  true
 home_z_first                                 false
 currentcontrol_module_enable                 true
 
+digipot_factor_rev12                         113.3
+digipot_factor                               128
+
 ##################################
 ##################################
 ##################################

--- a/src/libs/Kernel.cpp
+++ b/src/libs/Kernel.cpp
@@ -28,6 +28,7 @@
 #include "EndstopsPublicAccess.h"
 #include "Configurator.h"
 #include "SimpleShell.h"
+#include "Revision.h"
 
 #ifndef NO_TOOLS_LASER
 #include "Laser.h"
@@ -163,10 +164,11 @@ Kernel::Kernel()
     this->step_ticker->set_unstep_time( microseconds_per_step_pulse );
 
     // Core modules
-    this->add_module( this->conveyor       = new Conveyor()      );
-    this->add_module( this->gcode_dispatch = new GcodeDispatch() );
-    this->add_module( this->robot          = new Robot()         );
-    this->add_module( this->simpleshell    = new SimpleShell()   );
+    this->add_module( this->conveyor       = new Conveyor()        );
+    this->add_module( this->gcode_dispatch = new GcodeDispatch()   );
+    this->add_module( this->robot          = new Robot()           );
+    this->add_module( this->simpleshell    = new SimpleShell()     );
+    this->add_module( this->revision       = new RevisionManager() );
 
     this->planner = new Planner();
     this->configurator = new Configurator();

--- a/src/libs/Kernel.h
+++ b/src/libs/Kernel.h
@@ -32,6 +32,7 @@ class Adc;
 class PublicData;
 class SimpleShell;
 class Configurator;
+class RevisionManager;
 
 class Kernel {
     public:
@@ -67,6 +68,7 @@ class Kernel {
         Conveyor*         conveyor;
         Configurator*     configurator;
         SimpleShell*      simpleshell;
+        RevisionManager*  revision;
 
         SlowTicker*       slow_ticker;
         StepTicker*       step_ticker;

--- a/src/libs/Revision.cpp
+++ b/src/libs/Revision.cpp
@@ -1,0 +1,62 @@
+#include "checksumm.h"
+#include "Config.h"
+#include "ConfigValue.h"
+#include "libs/Pin.h"
+#include "libs/Kernel.h"
+#include "libs/utils.h"
+#include "Revision.h"
+
+
+#define pcb_revision_bit_0           CHECKSUM("pcb_revision_bit_0")
+#define pcb_revision_bit_1           CHECKSUM("pcb_revision_bit_1")
+
+static const char* REV12_NAME = "12";
+static const char* REVA_NAME = "A";
+static const char* REVB_NAME = "B";
+static const char* REVC_NAME = "C";
+static const char* REVINVALID_NAME = "INVALID";
+
+const char *string_from_rev(const Rev& r) {
+    switch (r) {
+        case REV_12:
+            return REV12_NAME;
+        case REV_A:
+            return REVA_NAME;
+        case REV_B:
+            return REVB_NAME;
+        case REV_C:
+            return REVC_NAME;
+        case REV_INVALID:
+        default:
+            return REVINVALID_NAME;
+    }
+}
+
+void RevisionManager::on_module_loaded() {
+    pcb_revision = get_pcb_revision();
+}
+
+// read GPIO to determine the major version number of the OT2 stepper driver hardware
+Rev RevisionManager::get_pcb_revision() const
+{
+    Pin *rev_bit_0 = new Pin();
+    Pin *rev_bit_1 = new Pin();
+    rev_bit_0->from_string(THEKERNEL->config->value(pcb_revision_bit_0)->as_string())->as_input();
+    rev_bit_1->from_string(THEKERNEL->config->value(pcb_revision_bit_1)->as_string())->as_input();
+    safe_delay_us(200);  // make sure the pins have settled
+    const uint8_t rev_byte = (((uint8_t)rev_bit_1->get()) << 1) | (uint8_t)rev_bit_0->get();
+    switch (rev_byte) {
+        case 0:
+            return REV_12;
+        case 1:
+            return REV_A;
+        case 2:
+            return REV_B;
+        case 3:
+            return REV_C;
+        default:
+            // this can never happen because we're only setting 2 bits but why
+            // not be careful
+            return REV_INVALID;
+    }
+}

--- a/src/libs/Revision.h
+++ b/src/libs/Revision.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "Module.h"
+
+enum Rev: uint8_t {
+    REV_INVALID = 0,
+    REV_12 = 1,
+    REV_A = 2,
+    REV_B = 3,
+    REV_C = 4
+};
+
+const char *string_from_rev(const Rev& r);
+
+class RevisionManager : public Module
+{
+public:
+    RevisionManager() {}
+    void on_module_loaded();
+    Rev pcb_revision = Rev::REV_12;
+private:
+     Rev get_pcb_revision() const;
+};

--- a/src/modules/utils/currentcontrol/CurrentControl.cpp
+++ b/src/modules/utils/currentcontrol/CurrentControl.cpp
@@ -4,6 +4,7 @@
 #include "libs/utils.h"
 #include "ConfigValue.h"
 #include "libs/StreamOutput.h"
+#include "libs/Revision.h"
 
 #include "Gcode.h"
 #include "Config.h"
@@ -29,6 +30,7 @@ using namespace std;
 #define digipotchip_checksum                    CHECKSUM("digipotchip")
 #define digipot_max_current                     CHECKSUM("digipot_max_current")
 #define digipot_factor                          CHECKSUM("digipot_factor")
+#define digipot_factor_rev12                    CHECKSUM("digipot_factor_rev12")
 
 #define mcp4451_checksum                        CHECKSUM("mcp4451")
 #define ad5206_checksum                         CHECKSUM("ad5206")
@@ -60,7 +62,11 @@ void CurrentControl::on_module_loaded()
     }
 
     digipot->set_max_current( THEKERNEL->config->value(digipot_max_current )->by_default(2.0f)->as_number());
-    digipot->set_factor( THEKERNEL->config->value(digipot_factor )->by_default(113.33f)->as_number());
+    if (THEKERNEL->revision->pcb_revision > REV_12) {
+        digipot->set_factor( THEKERNEL->config->value(digipot_factor      )->by_default(128.0f)->as_number());
+    } else {
+        digipot->set_factor( THEKERNEL->config->value(digipot_factor_rev12)->by_default(113.33f)->as_number());
+    }
 
     // Get configuration
     this->digipot->set_current(0, THEKERNEL->config->value(alpha_current_checksum  )->by_default(0.8f)->as_number());

--- a/src/modules/utils/simpleshell/SimpleShell.cpp
+++ b/src/modules/utils/simpleshell/SimpleShell.cpp
@@ -32,6 +32,7 @@
 #include "StepperMotor.h"
 #include "Configurator.h"
 #include "Block.h"
+#include "libs/Revision.h"
 
 #include "TemperatureControlPublicAccess.h"
 #include "EndstopsPublicAccess.h"
@@ -57,8 +58,6 @@ extern unsigned int g_maximumHeapAddress;
 #include <stdint.h>
 #include <functional>
 
-#define pcb_revision_bit_0           CHECKSUM("pcb_revision_bit_0")
-#define pcb_revision_bit_1           CHECKSUM("pcb_revision_bit_1")
 
 extern "C" uint32_t  __end__;
 extern "C" uint32_t  __malloc_free_list;
@@ -99,7 +98,6 @@ const SimpleShell::ptentry_t SimpleShell::commands_table[] = {
 };
 
 int SimpleShell::reset_delay_secs = 0;
-uint8_t SimpleShell::pcb_revision = 12;
 
 // Adam Greens heap walk from http://mbed.org/forum/mbed/topic/2701/?page=4#comment-22556
 static uint32_t heapWalk(StreamOutput *stream, bool verbose)
@@ -165,7 +163,6 @@ void SimpleShell::on_module_loaded()
 
     reset_delay_secs = 0;
 
-    pcb_revision = get_pcb_revision();
 }
 
 void SimpleShell::on_second_tick(void *)
@@ -634,19 +631,7 @@ void SimpleShell::net_command( string parameters, StreamOutput *stream)
     }
 }
 
-// read GPIO to determine the major version number of the OT2 stepper driver hardware
-uint8_t SimpleShell::get_pcb_revision()
-{
-    uint8_t ot_pcb_rev = 12;  // production began at v12
-    Pin *rev_bit_0 = new Pin();
-    Pin *rev_bit_1 = new Pin();
-    rev_bit_0->from_string(THEKERNEL->config->value(pcb_revision_bit_0)->as_string())->as_input();
-    rev_bit_1->from_string(THEKERNEL->config->value(pcb_revision_bit_1)->as_string())->as_input();
-    safe_delay_us(200);  // make sure the pins have settled
-    if (rev_bit_0->get()) ot_pcb_rev += 1;
-    if (rev_bit_1->get()) ot_pcb_rev += 2;
-    return ot_pcb_rev;
-}
+
 
 // print out build version
 void SimpleShell::version_command( string parameters, StreamOutput *stream)
@@ -654,7 +639,11 @@ void SimpleShell::version_command( string parameters, StreamOutput *stream)
     Version vers;
     uint32_t dev = getDeviceType();
     const char *mcu = (dev & 0x00100000) ? "LPC1769" : "LPC1768";
-    stream->printf("Build version: %s, Build date: %s, PCB Rev: %d, MCU: %s, System Clock: %ldMHz\r\n", vers.get_build(), vers.get_build_date(), pcb_revision, mcu, SystemCoreClock / 1000000);
+    stream->printf(
+        "Build version: %s, Build date: %s, PCB Rev: %s, MCU: %s, System Clock: %ldMHz\r\n",
+        vers.get_build(), vers.get_build_date(),
+        string_from_rev(THEKERNEL->revision->pcb_revision),
+        mcu, SystemCoreClock / 1000000);
     #ifdef CNC
     stream->printf("  CNC Build ");
     #endif

--- a/src/modules/utils/simpleshell/SimpleShell.h
+++ b/src/modules/utils/simpleshell/SimpleShell.h
@@ -61,8 +61,6 @@ private:
 
     static void test_command( string parameters, StreamOutput *stream);
 
-    static uint8_t get_pcb_revision();
-
     typedef void (*PFUNC)(string parameters, StreamOutput *stream);
     typedef struct {
         const char *command;
@@ -71,6 +69,4 @@ private:
 
     static const ptentry_t commands_table[];
     static int reset_delay_secs;
-
-    static uint8_t pcb_revision;
 };


### PR DESCRIPTION
The new motor controller board will have some pins identified as revision pins and set with resistors. Those pins are configured as internal pull down, inverted (resistors are not populated currently). See the issue for more.

On revisions newer than what is currently shipping, we will have a different motor current control circuit that requires a different digipot transducer value (aka current * transducer = digipot command to achieve current). So we need to read the revision bits and use different values based on them, while also keeping the transducer value configurable.

This PR therefore
- Moves the revision bit parsing into its own module since it was previously in the shell module, which seems odd
- Uses that in the current control module to decide whether we look at the `digipot_factor` config element (for new-rev boards; default 128) or the `digipot_factor_rev12` config element (old and current boards; default 113.3).

## Testing
This compiles and runs normally but I don't have the equipment to either modify the revision bits or test the motor current, unfortunately. It's ok for this to need further changes after the new boards come in, but we should make sure it uses the same current as before the patch (pretty sure it's fine) - @djgomez-opentrons could you check on that?

Closes https://github.com/Opentrons/opentrons/issues/5287