### PR TITLE
refactor(config,endstop): disable endstop pin pull on new rev

### DIFF
--- a/src/config.default
+++ b/src/config.default
@@ -132,6 +132,7 @@ endstop.minx.axis                            X
 endstop.minx.enable                          true
 endstop.minx.limit_enable                    true
 endstop.minx.pin                             1.24!^
+endstop.minx.pin_revA                        1.24!-
 endstop.minx.homing_direction                home_to_max
 endstop.minx.homing_position                 421
 endstop.minx.max_travel                      430
@@ -144,6 +145,7 @@ endstop.miny.axis                            Y
 endstop.miny.enable                          true
 endstop.miny.limit_enable                    false
 endstop.miny.pin                             1.25!^
+endstop.miny.pin_revA                        1.25!-
 endstop.miny.homing_direction                home_to_max
 endstop.miny.homing_position                 353
 endstop.miny.max_travel                      370
@@ -156,6 +158,7 @@ endstop.minz.axis                            Z
 endstop.minz.enable                          true
 endstop.minz.limit_enable                    true
 endstop.minz.pin                             1.26^
+endstop.minz.pin_revA                        1.26-
 endstop.minz.homing_direction                home_to_max
 endstop.minz.homing_position                 220
 endstop.minz.max_travel                      230
@@ -168,6 +171,7 @@ endstop.mina.axis                            A
 endstop.mina.enable                          true
 endstop.mina.limit_enable                    true
 endstop.mina.pin                             1.27^
+endstop.mina.pin_revA                        1.27-
 endstop.mina.homing_direction                home_to_max
 endstop.mina.homing_position                 220
 endstop.mina.max_travel                      230
@@ -180,6 +184,7 @@ endstop.minb.axis                            B
 endstop.minb.enable                          true
 endstop.minb.limit_enable                    true
 endstop.minb.pin                             1.28^
+endstop.minb.pin_revA                        1.28-
 endstop.minb.homing_direction                home_to_max
 endstop.minb.homing_position                 20
 endstop.minb.max_travel                      30
@@ -192,6 +197,7 @@ endstop.minc.axis                            C
 endstop.minc.enable                          true
 endstop.minc.limit_enable                    true
 endstop.minc.pin                             1.29^
+endstop.minc.pin_revA                        1.29-
 endstop.minc.homing_direction                home_to_max
 endstop.minc.homing_position                 20
 endstop.minc.max_travel                      30

--- a/src/config.default
+++ b/src/config.default
@@ -212,7 +212,7 @@ endstop.minc.retract                         2
 # TIP PROBE
 
 zprobe.enable                                true
-zprobe.probe_pin                             0.16
+zprobe.probe_pin                             0.16-
 zprobe.slow_feedrate                         5
 zprobe.fast_feedrate                         150
 zprobe.return_feedrate                       150

--- a/src/libs/ConfigValue.cpp
+++ b/src/libs/ConfigValue.cpp
@@ -63,7 +63,7 @@ ConfigValue *ConfigValue::required()
     return this;
 }
 
-float ConfigValue::as_number()
+float ConfigValue::as_number() const
 {
     if( this->found == false && this->default_set == true ) {
         return this->default_double;
@@ -79,7 +79,7 @@ float ConfigValue::as_number()
     }
 }
 
-int ConfigValue::as_int()
+int ConfigValue::as_int() const
 {
     if( this->found == false && this->default_set == true ) {
         return this->default_int;
@@ -95,12 +95,12 @@ int ConfigValue::as_int()
     }
 }
 
-std::string ConfigValue::as_string()
+std::string ConfigValue::as_string() const
 {
     return this->value;
 }
 
-bool ConfigValue::as_bool()
+bool ConfigValue::as_bool() const
 {
     if( this->found == false && this->default_set == true ) {
         return this->default_int;
@@ -134,7 +134,7 @@ ConfigValue *ConfigValue::by_default(string val)
     return this;
 }
 
-bool ConfigValue::has_characters( const char *mask )
+bool ConfigValue::has_characters( const char *mask ) const
 {
     if( this->value.find_first_of(mask) != string::npos ) {
         return true;
@@ -143,8 +143,11 @@ bool ConfigValue::has_characters( const char *mask )
     }
 }
 
-bool ConfigValue::is_inverted()
+bool ConfigValue::is_inverted() const
 {
     return this->has_characters("!");
 }
 
+bool ConfigValue::value_found() const {
+    return this->found;
+}

--- a/src/libs/ConfigValue.h
+++ b/src/libs/ConfigValue.h
@@ -19,16 +19,16 @@ class ConfigValue{
         ConfigValue& operator= (const ConfigValue& to_copy);
         void clear();
         ConfigValue* required();
-        float as_number();
-        int as_int();
-        bool as_bool();
-        string as_string();
+        float as_number() const;
+        int as_int() const;
+        bool as_bool() const;
+        string as_string() const;
+        bool value_found() const;
 
         ConfigValue* by_default(float val);
         ConfigValue* by_default(string val);
         ConfigValue* by_default(int val);
-        bool is_inverted();
-
+        bool is_inverted() const;
 
         friend class ConfigCache;
         friend class Config;
@@ -37,7 +37,7 @@ class ConfigValue{
         friend class FileConfigSource;
 
     private:
-        bool has_characters( const char* mask );
+        bool has_characters( const char* mask ) const;
         string value;
         int default_int;
         float default_double;


### PR DESCRIPTION
New revisions of the motor controller board require different pin configurations on the endstops - their pull resistors have to be disabled. To achieve this while keeping a single binary, this PR adds reading multiple configurations keyed by revision to the pin config for endstops. In addition to specifying `endstop.minx.pin` (for instance) you can also specify `endstop.minx.pin_revA`. When the config is loaded, the code will
1. identify the current board revision
2. look for the config for the most recent revision (C > B > A > 12 > unknown/default) that is at or under the current board revision 
3. apply that

You can therefore have a config like this:
```
endstop.minx.pin_revA 1.26!-
endstop.minx.pin 1.26!^
```

and rev 12/previous will read 1.26!^, while rev A and subsequent will read 1.26!- (see [smoothieware docs](http://smoothieware.org/pin-configuration) for more explanations of the pin config syntax).

Also, this PR then adds the new configs for rev A and subsequent.

Closes https://github.com/Opentrons/opentrons/issues/5627

## Testing
- Put this on a robot (build it, then move the old smoothie.hex out of /usr/lib/firmware and move this in and restart the robot)
- See if you can still home